### PR TITLE
Add optional cache for Statsguru pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data/old/*.csv
 __pycache__/
 stats_old.py
 scraper.py
+cache

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ asdf install
 pip install -r requirements.txt
 ```
 
-Then run the Python scripts. For instance, to scrape the latest data from
-Statsguru, `python update_data.py`.
+Then run the Python scripts. For instance, to scrape the latest data
+from Statsguru, `python update_data.py`. To cache the HTML from
+Statsguru (to make future scrapes faster), set `STATSGURU_CACHE=cache`
+(or another directory of your choosing.
 
 [blog]: https://brasier.me/pandas/2020/06/10/neeerd-pledge/


### PR DESCRIPTION
This stops hammering Statsguru so much, and means re-running full scrapes should be easier in future. It might not be _quick_, but it will be quicker. Local examples:

    $ time python update_data.py > /dev/null

    real        9m13.344s
    user        2m47.494s
    sys         0m1.694s
    $ time STATSGURU_CACHE=cache python update_data.py > /dev/null

    real        5m28.433s
    user        2m42.252s
    sys         0m1.662s