### PR TITLE
Speed up scrapers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.22.0
-numpy==1.17.4
-pandas==1.0.5
+numpy==1.18.5
+pandas==1.4.4
 beautifulsoup4==4.9.3
 python_dateutil==2.8.1
 black==22.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.22.0
 numpy==1.18.5
 pandas==1.4.4
-beautifulsoup4==4.9.3
+selectolax==0.3.8
 python_dateutil==2.8.1
 black==22.8.0

--- a/teams.py
+++ b/teams.py
@@ -222,4 +222,5 @@ team_lookup = {
     "COK": "Cook Islands",
     "GRC-W": "Greece Women",
     "SRB-W": "Serbia Women",
+    "SWA": "Eswatini",
 }


### PR DESCRIPTION
This significantly speeds up the scrapers.

## Perform fewer Pandas appends

https://github.com/pandas-dev/pandas/issues/35407 says:

> Unless I'm mistaken, users are always better off building up a list of values and passing them to the constructor, or building up a list of NDFrames followed by a single `concat`.

So let's do that. It is significantly faster: https://stackoverflow.com/a/56746204

Using py-spy (https://github.com/benfred/py-spy) for flamegraphs and good old `time` for overall timings, I created this comparison.

Before (uncached, for women's Test team records only):

```shell
$ rm -r data/*
$ sudo time py-spy record -o before.svg -- python update_data.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.

# snip
Scraping page 4
https://stats.espncricinfo.com/ci/engine/stats/index.html?class=8;filter=advanced;orderby=start;page=4;size=200;template=results;type=team;view=innings
All done!

py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'before.svg'. Samples: 1235 Errors: 0
       28.53 real        10.93 user         1.65 sys
```

![before](https://user-images.githubusercontent.com/1120328/190920503-d8d11fb7-3f28-4e53-89e5-dbb5ceb2c3d8.svg)


After:

```shell
$ rm -r data/*
$ sudo time py-spy record -o list.svg -- python update_data.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.

# snip
Scraping page 4
https://stats.espncricinfo.com/ci/engine/stats/index.html?class=8;filter=advanced;orderby=start;page=4;size=200;template=results;type=team;view=innings
All done!

py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'list.svg'. Samples: 395 Errors: 0
       20.91 real         4.06 user         1.41 sys
```

![list](https://user-images.githubusercontent.com/1120328/190920527-2e65a609-b15c-4eae-ba60-c3bb9f17557b.svg)


For a full update, before:

```shell
$ sudo time py-spy record -o before-2.svg -- python update_data.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.
# snip
py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'before-2.svg'. Samples: 21656 Errors: 0
      626.02 real       194.27 user        31.50 sys
```

![before-2](https://user-images.githubusercontent.com/1120328/190920538-ca5d5498-5b94-4189-b83e-4bc9ac146bcb.svg)


And after:

```shell
$ sudo time py-spy record -o list-2.svg -- python update_data.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.
# snip
py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'list-2.svg'. Samples: 8958 Errors: 0
      492.66 real        85.26 user        26.58 sys
```

![list-2](https://user-images.githubusercontent.com/1120328/190920553-a335adb5-b69b-46b3-a6d9-346c6f842bf3.svg)


If we then add the cache (https://github.com/obrasier/cricketstats/pull/6) into the equation:

```shell
      226.39 real        73.39 user        11.82 sys
```

This needed an upgrade to Pandas 1.4 in order to work with the nullable integer types. This was to take https://github.com/pandas-dev/pandas/pull/43949 which fixed https://github.com/pandas-dev/pandas/issues/25472.

## Selectolax

The second commit uses Selectolax to speed up HTML parsing. https://rushter.com/blog/python-fast-html-parser/ has a good overview, and this is very straightforward.

Combining all these changes gives a big improvement: with caching, more efficient dataframe construction, and a faster HTML parser, we go from 626 seconds (just over 10 minutes) to 155 seconds (just over 2.5 minutes)!

```shell
$ sudo time py-spy record -o selectolax-cached.svg -- python update_data.py
py-spy> Sampling process 100 times a second. Press Control-C to exit.
# snip
py-spy> Stopped sampling because process exited
py-spy> Wrote flamegraph data to 'selectolax-cached.svg'. Samples: 2618 Errors: 0
      155.07 real        21.05 user         8.74 sys
```

![selectolax-cached](https://user-images.githubusercontent.com/1120328/190920561-d119548f-5366-4ece-b2ca-88cf5459c514.svg)

We now spend about half our time just writing the CSVs!

